### PR TITLE
Looks like the code can be simplified

### DIFF
--- a/src/lib/jotai.ts
+++ b/src/lib/jotai.ts
@@ -12,10 +12,6 @@ export function vanjsJotaiFactory(): UseAtom {
   return <Value, Args extends unknown[], Result>(atom: WritableAtom<Value, Args, Result> | Atom<Value>) => {
     const atomState = van.state(store.get(atom))
     return new Proxy(atomState, {
-      get(state, prop) {
-        const r = Reflect.get(state, prop)
-        return prop === 'val' ? store.get(atom) : r
-      },
       set(state, prop, newValue: Value) {
         const ret = Reflect.set(state, prop, newValue)
         if (prop === 'val' && 'write' in atom && newValue !== store.get(atom)) {


### PR DESCRIPTION
Looks like the code can be simplified, as the state in jotai store is always in sync with the state in VanJS. Thus in the `get` accessor, directly getting the value from the VanJS state is enough.

Out of curiosity, what is the main benefit of using jotai? Is it because of the support of state persistence? Persistence doesn't seem to work when I try locally on my side :-(